### PR TITLE
Allow float Binning

### DIFF
--- a/mdocfile/section_data.py
+++ b/mdocfile/section_data.py
@@ -29,7 +29,7 @@ class MdocSectionData(BaseModel):
     ImageShift: Optional[Tuple[float, float]]
     RotationAngle: Optional[float]
     ExposureTime: Optional[float]
-    Binning: Optional[int]
+    Binning: Optional[float]
     UsingCDS: Optional[bool]
     CameraIndex: Optional[int]
     DividedBy2: Optional[bool]


### PR DESCRIPTION
Reading from my data failed due to non-integer binning. In the mdoc it's 0.5; I suspect it might be because it's superresolution data.

Anyways, this small change fixed it!
