### PR TITLE
Add write functionality

### DIFF
--- a/mdocfile/__init__.py
+++ b/mdocfile/__init__.py
@@ -1,1 +1,1 @@
-from .functions import read, write
+from .functions import read

--- a/mdocfile/__init__.py
+++ b/mdocfile/__init__.py
@@ -1,1 +1,1 @@
-from .functions import read
+from .functions import read, write

--- a/mdocfile/functions.py
+++ b/mdocfile/functions.py
@@ -21,9 +21,6 @@ def read(filename: PathLike, camel_to_snake: bool = True) -> pd.DataFrame:
         dataframe containing info from mdoc file
     """
     mdoc = Mdoc.from_file(filename)
-    if not as_dataframe:
-        return mdoc
-
     global_data = mdoc.global_data.dict()
     section_data = {
         k: [section.dict()[k] for section in mdoc.section_data]

--- a/mdocfile/functions.py
+++ b/mdocfile/functions.py
@@ -1,4 +1,5 @@
 from os import PathLike
+from pathlib import Path
 
 import pandas as pd
 
@@ -6,7 +7,7 @@ from .mdoc import Mdoc
 from .utils import camel_to_snake as _camel_to_snake
 
 
-def read(filename: PathLike, camel_to_snake: bool = True) -> pd.DataFrame:
+def read(filename: PathLike, camel_to_snake: bool = True, as_dataframe: bool = True) -> pd.DataFrame:
     """Read an mdoc file as a pandas dataframe.
 
     Parameters
@@ -21,6 +22,9 @@ def read(filename: PathLike, camel_to_snake: bool = True) -> pd.DataFrame:
         dataframe containing info from mdoc file
     """
     mdoc = Mdoc.from_file(filename)
+    if not as_dataframe:
+        return mdoc
+
     global_data = mdoc.global_data.dict()
     section_data = {
         k: [section.dict()[k] for section in mdoc.section_data]
@@ -39,3 +43,14 @@ def read(filename: PathLike, camel_to_snake: bool = True) -> pd.DataFrame:
     if camel_to_snake is True:
         df.columns = [_camel_to_snake(h) for h in df.columns]
     return df
+
+
+def write(mdoc: Mdoc, filename: PathLike, overwrite: bool = False) -> None:
+    """
+    Write an Mdoc file
+    """
+    path = Path(filename)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f'{path} exists. Use overwrite=True to overwrite.')
+    with open(filename, 'w+') as f:
+        f.write(mdoc.to_string())

--- a/mdocfile/functions.py
+++ b/mdocfile/functions.py
@@ -6,7 +6,7 @@ from .mdoc import Mdoc
 from .utils import camel_to_snake as _camel_to_snake
 
 
-def read(filename: PathLike, camel_to_snake: bool = True, as_dataframe: bool = True) -> pd.DataFrame:
+def read(filename: PathLike, camel_to_snake: bool = True) -> pd.DataFrame:
     """Read an mdoc file as a pandas dataframe.
 
     Parameters

--- a/mdocfile/functions.py
+++ b/mdocfile/functions.py
@@ -1,5 +1,4 @@
 from os import PathLike
-from pathlib import Path
 
 import pandas as pd
 

--- a/mdocfile/functions.py
+++ b/mdocfile/functions.py
@@ -39,14 +39,3 @@ def read(filename: PathLike, camel_to_snake: bool = True) -> pd.DataFrame:
     if camel_to_snake is True:
         df.columns = [_camel_to_snake(h) for h in df.columns]
     return df
-
-
-def write(mdoc: Mdoc, filename: PathLike, overwrite: bool = False) -> None:
-    """
-    Write an Mdoc file
-    """
-    path = Path(filename)
-    if path.exists() and not overwrite:
-        raise FileExistsError(f'{path} exists. Use overwrite=True to overwrite.')
-    with open(filename, 'w+') as f:
-        f.write(mdoc.to_string())

--- a/mdocfile/global_data.py
+++ b/mdocfile/global_data.py
@@ -36,3 +36,15 @@ class MdocGlobalData(BaseModel):
         ]
         data = {k: v for k, v in key_value_pairs}
         return cls(**data)
+
+    def to_string(self):
+        lines = []
+        for k, v in self.dict().items():
+            if v is None:
+                continue
+            if isinstance(v, tuple):
+                v = ' '.join(str(el) for el in v)
+            if v == 'nan':
+                v = 'NaN'
+            lines.append(f'{k} = {v}')
+        return '\n'.join(lines)

--- a/mdocfile/global_data.py
+++ b/mdocfile/global_data.py
@@ -15,6 +15,7 @@ class MdocGlobalData(BaseModel):
     ImageSeries: Optional[int]
     ImageFile: Optional[Path]
     PixelSpacing: Optional[float]
+    Voltage: Optional[int]
 
     @validator('ImageSize', pre=True)
     def multi_number_string_to_tuple(cls, value: str):

--- a/mdocfile/global_data.py
+++ b/mdocfile/global_data.py
@@ -15,7 +15,7 @@ class MdocGlobalData(BaseModel):
     ImageSeries: Optional[int]
     ImageFile: Optional[Path]
     PixelSpacing: Optional[float]
-    Voltage: Optional[int]
+    Voltage: Optional[float]
 
     @validator('ImageSize', pre=True)
     def multi_number_string_to_tuple(cls, value: str):

--- a/mdocfile/mdoc.py
+++ b/mdocfile/mdoc.py
@@ -30,3 +30,12 @@ class Mdoc(BaseModel):
             ]
         return cls(titles=titles, global_data=global_data, section_data=section_data)
 
+    def to_string(self):
+        """
+        Generate the string representation of the Mdoc data
+        """
+        return '\n\n'.join([
+            self.global_data.to_string(),
+            '\n\n'.join(self.titles),
+            '\n\n'.join(section.to_string() for section in self.section_data),
+        ])

--- a/mdocfile/section_data.py
+++ b/mdocfile/section_data.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple, Union, Sequence, List
 
@@ -46,7 +45,7 @@ class MdocSectionData(BaseModel):
     SubFramePath: Optional[Path]
     NumSubFrames: Optional[int]
     FrameDosesAndNumbers: Optional[Sequence[Tuple[float, int]]]
-    DateTime: Optional[datetime]
+    DateTime: Optional[str]
     NavigatorLabel: Optional[str]
     FilterSlitAndLoss: Optional[Tuple[float, float]]
     ChannelName: Optional[str]
@@ -74,10 +73,6 @@ class MdocSectionData(BaseModel):
     def multi_number_string_to_tuple(cls, value: str):
         return tuple(value.split())
 
-    @validator('DateTime', pre=True)
-    def mdoc_datetime_to_datetime(cls, value: str):
-        return datetime.strptime(value, '%d-%b-%y  %H:%M:%S', )
-
     @classmethod
     def from_lines(cls, lines: List[str]):
         lines = [line.strip('[]')
@@ -100,11 +95,9 @@ class MdocSectionData(BaseModel):
         for k, v in data.items():
             if v is None:
                 continue
-            if isinstance(v, tuple):
+            elif isinstance(v, tuple):
                 v = ' '.join(str(el) for el in v)
-            if v == 'nan':
+            elif v == 'nan':
                 v = 'NaN'
-            if isinstance(v, datetime):
-                v = v.strftime('%y-%b-%d  %H:%M:%S')
             lines.append(f'{k} = {v}')
         return '\n'.join(lines)

--- a/mdocfile/section_data.py
+++ b/mdocfile/section_data.py
@@ -104,5 +104,9 @@ class MdocSectionData(BaseModel):
                 v = ' '.join(str(el) for el in v)
             if v == 'nan':
                 v = 'NaN'
+            if isinstance(v, datetime):
+                v = v.strftime('%y-%b-%d  %H:%M:%S')
+            if isinstance(v, Path):
+                v = fr'X:\spoof\frames\{v.name}'
             lines.append(f'{k} = {v}')
         return '\n'.join(lines)

--- a/mdocfile/section_data.py
+++ b/mdocfile/section_data.py
@@ -92,3 +92,17 @@ class MdocSectionData(BaseModel):
         ]
         lines = {k: v for k, v in key_value_pairs}
         return cls(**lines)
+
+    def to_string(self):
+        dct = self.dict()
+        zvalue = dct.pop('ZValue')
+        lines = [f'[ZValue = {zvalue}]']
+        for k, v in dct.items():
+            if v is None:
+                continue
+            if isinstance(v, tuple):
+                v = ' '.join(str(el) for el in v)
+            if v == 'nan':
+                v = 'NaN'
+            lines.append(f'{k} = {v}')
+        return '\n'.join(lines)

--- a/mdocfile/section_data.py
+++ b/mdocfile/section_data.py
@@ -106,7 +106,5 @@ class MdocSectionData(BaseModel):
                 v = 'NaN'
             if isinstance(v, datetime):
                 v = v.strftime('%y-%b-%d  %H:%M:%S')
-            if isinstance(v, Path):
-                v = fr'X:\spoof\frames\{v.name}'
             lines.append(f'{k} = {v}')
         return '\n'.join(lines)

--- a/mdocfile/section_data.py
+++ b/mdocfile/section_data.py
@@ -94,10 +94,10 @@ class MdocSectionData(BaseModel):
         return cls(**lines)
 
     def to_string(self):
-        dct = self.dict()
-        zvalue = dct.pop('ZValue')
-        lines = [f'[ZValue = {zvalue}]']
-        for k, v in dct.items():
+        data = self.dict()
+        z_value = data.pop('ZValue')
+        lines = [f'[ZValue = {z_value}]']
+        for k, v in data.items():
             if v is None:
                 continue
             if isinstance(v, tuple):

--- a/tests/test_mdoc.py
+++ b/tests/test_mdoc.py
@@ -1,4 +1,5 @@
 from mdocfile.mdoc import Mdoc
+from tempfile import NamedTemporaryFile
 
 
 def test_mdoc_from_tilt_series_mdoc_file(tilt_series_mdoc_file):
@@ -7,3 +8,12 @@ def test_mdoc_from_tilt_series_mdoc_file(tilt_series_mdoc_file):
     assert len(mdoc.titles) == 2
     assert mdoc.global_data.PixelSpacing == 5.4
     assert len(mdoc.section_data) == 41
+
+
+def test_to_string_is_valid_mdoc(tilt_series_mdoc_file):
+    mdoc = Mdoc.from_file(tilt_series_mdoc_file)
+    with NamedTemporaryFile() as tmp:
+        tmp.write(mdoc.to_string().encode())
+        mdoc2 = Mdoc.from_file(tmp.name)
+    for (k1, v1), (k2, v2) in zip(mdoc.section_data[0].dict().items(), mdoc2.section_data[0].dict().items()):
+        assert(v1 == v2), k1

--- a/tests/test_section_data.py
+++ b/tests/test_section_data.py
@@ -51,8 +51,4 @@ def test_section_data_from_lines():
     assert data.TargetDefocus == -4
     assert data.SubFramePath == Path(r'D:\DATA\Flo\HGK149_20151130\frames\TS_01_000_0.0.mrc')
     assert data.NumSubFrames == 8
-    assert data.DateTime == MdocSectionData.mdoc_datetime_to_datetime('30-Nov-15  15:21:38')
-
-
-
-
+    assert data.DateTime == '30-Nov-15  15:21:38'


### PR DESCRIPTION
This PR adds a `write` function that allows writing the `Mdoc` contents to a text file in the `mdoc` format.

To make it easier, I added a new flag to `read` so one can return simply the `Mdoc` object, otherwise I would have had to write a dataframe to `Mdoc` coversion, and this was quicker. That's certainly useful, so for a future PR.

I also snuck in a new field (`Voltage`) that was missing.
